### PR TITLE
Update convox CLI tool URL after the main website redesign

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL "com.github.actions.color"="blue"
 
 RUN apt-get -qq update && apt-get -qq -y install curl
 
-RUN curl -L https://convox.com/cli/linux/convox -o /tmp/convox \
+RUN curl -L https://github.com/convox/convox/releases/latest/download/convox-linux -o /tmp/convox \
     && mv /tmp/convox /usr/local/bin/convox \
     && chmod 755 /usr/local/bin/convox
 


### PR DESCRIPTION
CLI tool can't be fetched from original location. This action currently is fetching a 404 page into the action's Docker image. This means we can't deploy using the action after the convox.com website update.