### PR TITLE
Removed --wait option from entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,4 +22,4 @@ if [ "$INPUT_MANIFEST" != "" ]; then
     MANIFEST_COMMAND="-m $INPUT_MANIFEST"
 fi
 
-convox deploy --app $INPUT_APP --description "$INPUT_DESCRIPTION" $CACHED_COMMAND $MANIFEST_COMMAND --wait
+convox deploy --app $INPUT_APP --description "$INPUT_DESCRIPTION" $CACHED_COMMAND $MANIFEST_COMMAND


### PR DESCRIPTION
Fixes #10 .

For some reason it was working for quite a while, but today we have also hit these issues. `--wait` is not existing for couple of CLI versions already, thus its removal from entrypoint should fix the issue.

I have checked and `convox deploy` waits by default on 3.17.0